### PR TITLE
Remove 'Stanoviště' entry from burger menu navigation

### DIFF
--- a/apps/storefront/app/page.tsx
+++ b/apps/storefront/app/page.tsx
@@ -207,6 +207,10 @@ export default function Page() {
     () => detailedCartItems.reduce((sum, item) => sum + item.product.price * item.quantity, 0),
     [detailedCartItems],
   );
+  const visibleNavLinks = useMemo(
+    () => navLinks.filter((link) => link.label !== 'Stanoviště'),
+    [],
+  );
 
   const shippingOption = shippingMethods.find((method) => method.id === selectedShipping) ?? shippingMethods[0];
   const orderTotal = cartSubtotal + (shippingOption?.price ?? 0);
@@ -420,7 +424,7 @@ export default function Page() {
               className={`nav-links ${navOpen ? 'nav-links--open' : ''}`}
               onClick={() => setNavOpen(false)}
             >
-              {navLinks.map((link) => (
+              {visibleNavLinks.map((link) => (
                 <li key={link.href}>
                   <a href={link.href}>{link.label}</a>
                 </li>


### PR DESCRIPTION
### Motivation
- Hide the "Stanoviště" navigation item from the mobile/burger menu by filtering it out before rendering so it no longer appears in the collapsed navigation.

### Description
- Add a `visibleNavLinks` `useMemo` that returns `navLinks.filter((link) => link.label !== 'Stanoviště')` and use `visibleNavLinks` instead of `navLinks` when rendering the burger menu in `apps/storefront/app/page.tsx`.

### Testing
- Started the storefront dev server with `pnpm --filter storefront dev` (Next compiled and server became ready despite image fetch `ENETUNREACH` warnings) and ran a Playwright script that clicked the `.nav-toggle` and saved a screenshot to `artifacts/burger-menu.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690b8a9390832692ba795844bdc742)